### PR TITLE
feat: 전체 커피 메뉴 조회 API 구현

### DIFF
--- a/src/main/java/com/sparta/cafeorderback/controller/MenuController.java
+++ b/src/main/java/com/sparta/cafeorderback/controller/MenuController.java
@@ -1,0 +1,25 @@
+package com.sparta.cafeorderback.controller;
+
+import com.sparta.cafeorderback.dto.MenuDetailsResponse;
+import com.sparta.cafeorderback.service.MenuService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/menus")
+public class MenuController {
+
+  private final MenuService menuService;
+
+  @GetMapping("/coffee")
+  public ResponseEntity<List<MenuDetailsResponse>> getAll() {
+    List<MenuDetailsResponse> responses = menuService.getAllCoffee();
+    return ResponseEntity.status(HttpStatus.OK).body(responses);
+  }
+}

--- a/src/main/java/com/sparta/cafeorderback/dto/MenuDetailsResponse.java
+++ b/src/main/java/com/sparta/cafeorderback/dto/MenuDetailsResponse.java
@@ -1,0 +1,24 @@
+package com.sparta.cafeorderback.dto;
+
+import com.sparta.cafeorderback.entity.Menu;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MenuDetailsResponse {
+
+  private final Long id;
+  private final String name;
+  private final Long price;
+  private final String description;
+
+  public static MenuDetailsResponse from(Menu menu) {
+    return new MenuDetailsResponse(
+        menu.getId(),
+        menu.getName(),
+        menu.getPrice(),
+        menu.getDescription()
+    );
+  }
+}

--- a/src/main/java/com/sparta/cafeorderback/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/cafeorderback/repository/MenuRepository.java
@@ -1,0 +1,8 @@
+package com.sparta.cafeorderback.repository;
+
+import com.sparta.cafeorderback.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+}

--- a/src/main/java/com/sparta/cafeorderback/service/MenuService.java
+++ b/src/main/java/com/sparta/cafeorderback/service/MenuService.java
@@ -1,0 +1,23 @@
+package com.sparta.cafeorderback.service;
+
+import com.sparta.cafeorderback.dto.MenuDetailsResponse;
+import com.sparta.cafeorderback.repository.MenuRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MenuService {
+
+  private final MenuRepository menuRepository;
+
+  @Transactional(readOnly = true)
+  public List<MenuDetailsResponse> getAllCoffee() {
+
+    return menuRepository.findAll().stream()
+        .map(coffee -> MenuDetailsResponse.from(coffee))
+        .toList();
+  }
+}


### PR DESCRIPTION
### 주요 작업 내역
- 전체 메뉴 조회 API 구현

### 주의
메뉴 확대를 위해 API 경로를 `/api/menus/coffee`와 같이 분리했습니다. 
이후 메뉴가 non-coffee, dessert등 확대될 경우 Entity 및 로직은 리팩토링 예정입니다. 